### PR TITLE
Made the tribot-dax-walker plugin no longer be hardcoded to 0.0.7

### DIFF
--- a/src/main/kotlin/org/tribot/gradle/plugin/TribotPlugin.kt
+++ b/src/main/kotlin/org/tribot/gradle/plugin/TribotPlugin.kt
@@ -79,7 +79,7 @@ class TribotPlugin : Plugin<Project> {
             }
 
             if (it.findProperty("includeDaxWalker")?.toString().toBoolean()) {
-                it.dependencies.add("compileOnly", "org.tribot:tribot-dax-walker:0.0.7")
+                it.dependencies.add("compileOnly", "org.tribot:tribot-dax-walker:+")
             }
 
             // Add/check allatori - we only check the length to verify integrity before copying, this will be sufficient


### PR DESCRIPTION
The old version of tribot-dax-walker is fairly old and i dont like it.